### PR TITLE
Moving derive method and sampling options by generating None. [versio…

### DIFF
--- a/project/Publishing.scala
+++ b/project/Publishing.scala
@@ -40,7 +40,7 @@ object Publishing {
   }
 
   val versionSettings = Seq(
-    version := "0.36.0",
+    version := "0.37.0",
     credentials ++= defaultCredentials
   )
 

--- a/util-samplers/src/main/scala/com/outworkers/util/samplers/Generators.scala
+++ b/util-samplers/src/main/scala/com/outworkers/util/samplers/Generators.scala
@@ -21,7 +21,15 @@ trait Generators extends GenerationDomain {
    */
   def gen[T : Sample]: T = implicitly[Sample[T]].sample
 
-  def genOpt[T : Sample]: Option[T] = Some(implicitly[Sample[T]].sample)
+  def genOpt[T : Sample]: Option[T] = {
+    val bool = Random.nextBoolean()
+
+    if (bool) {
+      Some(implicitly[Sample[T]].sample)
+    } else {
+      None
+    }
+  }
 
   /**
     * Generates a list of elements based on an input collection type.

--- a/util-samplers/src/main/scala/com/outworkers/util/samplers/Sample.scala
+++ b/util-samplers/src/main/scala/com/outworkers/util/samplers/Sample.scala
@@ -29,6 +29,10 @@ trait Sample[T] {
 
 object Sample {
 
+  def derive[T : Sample, T1](fn: T => T1): Sample[T1] = new Sample[T1] {
+    override def sample: T1 = fn(gen[T])
+  }
+
   def arbitrary[T : Sample]: Arbitrary[T] = Arbitrary(generator[T])
 
   def generator[T : Sample]: Gen[T] = Gen.delay(gen[T])
@@ -59,10 +63,6 @@ object Sample {
 
 
 object Samples extends Generators {
-
-  def derive[T : Sample, T1](fn: T => T1): Sample[T1] = new Sample[T1] {
-    override def sample: T1 = fn(gen[T])
-  }
 
   private[this] val byteLimit = 127
   private[this] val shortLimit = 256


### PR DESCRIPTION
…n skip]

- Bumping version to `0.37.0`.
- Moving `derive` method to `Sample` companion object.